### PR TITLE
Fix bad link

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -28,7 +28,7 @@ graphics:
       src: /assets/img/circles/cpu.png
       alt: "CPU icon"
     title: Contribute
-    description: Everyone is welcome. [Learn how you can contribute](/join) to CivicActions Jekyll Vanilla site.
+    description: Everyone is welcome. [Learn how you can contribute](/ca-jekyll-vanilla/join) to CivicActions Jekyll Vanilla site.
 ---
 
 ## Get started

--- a/index.markdown
+++ b/index.markdown
@@ -28,7 +28,7 @@ graphics:
       src: /assets/img/circles/cpu.png
       alt: "CPU icon"
     title: Contribute
-    description: Everyone is welcome. [Learn how you can contribute](/ca-jekyll-vanilla/join) to CivicActions Jekyll Vanilla site.
+    description: Everyone is welcome. [Learn how you can contribute]({{ '/join' | relative_url }}) to CivicActions Jekyll Vanilla site.
 ---
 
 ## Get started


### PR DESCRIPTION
The /join page went to BASE_URL/join, a 404, and not BASE_URL/ca-jekyll-vanilla/join/. This fixes that.